### PR TITLE
Add Claude Code acmedns skill

### DIFF
--- a/skills/acmedns/.claude-plugin/plugin.json
+++ b/skills/acmedns/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "rwts-acmedns",
+  "description": "Configure SSL/TLS certificates via DNS-01 challenges with the RWTS ACME DNS infrastructure.",
+  "version": "1.0.0",
+  "author": { "name": "Real World Technology Solutions", "url": "https://rwts.com.au" },
+  "repository": { "type": "git", "url": "https://github.com/realworldtech/acmedns" }
+}

--- a/skills/acmedns/SKILL.md
+++ b/skills/acmedns/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: acmedns
+description: >
+  Use when configuring SSL/TLS certificates via DNS-01 challenges with the
+  RWTS ACME DNS infrastructure at acmedns.realworld.net.au. Also use when
+  the user needs wildcard certificates, SSL for non-publicly-accessible
+  servers, or mentions acmedns, ACME DNS, or DNS-01 challenge setup.
+---
+
+# RWTS ACME DNS — SSL Certificate Configuration
+
+Configures SSL/TLS certificates using DNS-01 challenges via the RWTS ACME DNS infrastructure.
+
+- **Base URL:** `https://acmedns.realworld.net.au`
+- **User UI:** `https://acmedns.realworld.net.au` — **Admin UI:** `https://admin.acmedns.realworld.net.au`
+- Both UIs require an API key. Mention these as alternatives if the user prefers a GUI workflow.
+
+## DNS-01 vs HTTP-01 Pre-Check
+
+```dot
+digraph dns01_check {
+  "Need wildcard cert?" [shape=diamond];
+  "Server publicly accessible\non ports 80/443?" [shape=diamond];
+  "Use HTTP-01\n(this skill not needed)" [shape=box];
+  "Use DNS-01\n(continue below)" [shape=box];
+
+  "Need wildcard cert?" -> "Use DNS-01\n(continue below)" [label="yes"];
+  "Need wildcard cert?" -> "Server publicly accessible\non ports 80/443?" [label="no"];
+  "Server publicly accessible\non ports 80/443?" -> "Use HTTP-01\n(this skill not needed)" [label="yes"];
+  "Server publicly accessible\non ports 80/443?" -> "Use DNS-01\n(continue below)" [label="no"];
+}
+```
+
+If HTTP-01 suffices, recommend it and stop. DNS-01 is for when HTTP-01 won't work.
+
+## Supported Platforms
+
+Traefik, Certbot, acme.sh, Nginx Proxy Manager, Caddy, Apache, Proxmox, HAProxy
+
+## Phase 1 — Assess
+
+1. Ask the user what **domain(s)** to secure.
+2. Ask which **platform** from the supported list above.
+3. **API key check:**
+   - **Has key** — verify with: `curl -s -H "X-API-Key: <key>" https://acmedns.realworld.net.au/api/info`
+   - **No key + admin access** — create via: `curl -s -X POST -H "Authorization: Bearer <master-key>" -H "Content-Type: application/json" -d '{"name":"..."}' https://acmedns.realworld.net.au/api/admin/keys`
+   - **No key + no admin** — tell user to contact an RWTS admin for an API key.
+4. **Check if domain already registered:** `curl -s -X POST -H "X-API-Key: <key>" -H "Content-Type: application/json" -d '{"domain":"<domain>"}' https://acmedns.realworld.net.au/api/lookup`
+   - **Found** — ask if user has the acme-dns credentials (username/password) from original registration. The `/lookup` endpoint does NOT return these. If they have credentials, skip to Phase 3. If not, re-register (Phase 2).
+   - **Not found (404)** — proceed to Phase 2.
+
+Propose every curl command and wait for user confirmation before executing.
+
+## Phase 2 — Register
+
+For multi-domain or SAN certs, repeat for each domain.
+
+1. Propose: `curl -s -X POST -H "X-API-Key: <key>" -H "Content-Type: application/json" -d '{"domain":"<domain>"}' https://acmedns.realworld.net.au/api/register`
+2. Capture the response: `subdomain`, `username`, `password`, `fulldomain`.
+3. **CRITICAL WARNING:** Tell user to save these credentials securely — they are returned **only once** and cannot be retrieved later.
+4. Present the CNAME record: `_acme-challenge.<domain> CNAME <subdomain>.acmedns.realworld.net.au`
+   - For wildcard `*.example.com`, the CNAME goes on `_acme-challenge.example.com` (the base domain).
+5. Guide DNS setup — if user needs help, `Read` the file `reference/dns-setup.md` from this skill directory.
+6. Optionally verify propagation: `dig CNAME _acme-challenge.<domain>`
+
+## Phase 3 — Configure
+
+**CRITICAL:** ACME clients must use `https://acmedns.realworld.net.au` as their server URL (root path). The `/update` endpoint is at the root, NOT under `/api/`. Getting this wrong causes silent failures.
+
+**Internal domains and DNS resolvers:** When securing internal or private domains, the local DNS resolver often cannot resolve the `_acme-challenge` CNAME or the acme-dns TXT records — these only exist in public DNS. Configure the ACME client to use external resolvers (e.g. `1.1.1.1:53`, `8.8.8.8:53`) for DNS propagation checks. Without this, the client may report that propagation failed even though the records are correct on the public internet. Each platform reference includes resolver configuration where supported.
+
+1. `Read` the platform reference file at `~/.claude/skills/acmedns/reference/platforms/<platform>.md`.
+2. Replace template variables with real registration data:
+   - `{{DOMAIN}}` — the domain
+   - `{{SUBDOMAIN}}` — subdomain from registration
+   - `{{USERNAME}}` — username from registration
+   - `{{PASSWORD}}` — password from registration
+   - `{{FULLDOMAIN}}` — `<subdomain>.acmedns.realworld.net.au`
+3. Present the configuration with explanation.
+4. Offer to write config files into the user's project (propose file paths and content, wait for confirmation).
+
+## Error Handling
+
+- Check `/api/health` at workflow start — if unhealthy, inform user and stop.
+- **429 (rate limited)** — tell user which limit was hit and to wait.
+- **401/403 (auth failure)** — re-check API key; it may be expired or revoked.
+- **Registration failure** — show error response, suggest `Read`ing `reference/api.md` for details.
+
+## Confirmation Gate Rules
+
+- **Every** API call must be proposed with the full curl command before execution.
+- Wait for user approval before running.
+- User can always choose to run commands themselves.
+- Never store or log API keys in files without explicit consent.

--- a/skills/acmedns/reference/api.md
+++ b/skills/acmedns/reference/api.md
@@ -1,0 +1,417 @@
+# RWTS ACME DNS — API Reference
+
+**Purpose:** Loaded on demand for troubleshooting and API questions about the RWTS ACME DNS registration service.
+
+---
+
+## Base URL
+
+```
+https://acmedns.realworld.net.au
+```
+
+## URL Convention
+
+All registration API endpoints use the `/api/` prefix externally. Traefik strips the `/api` prefix before routing requests to the Flask application internally.
+
+| External URL | Internal Flask route |
+|---|---|
+| `https://acmedns.realworld.net.au/api/register` | `/register` |
+| `https://acmedns.realworld.net.au/api/health` | `/health` |
+| `https://acmedns.realworld.net.au/update` | `/update` (direct to acme-dns, no stripping) |
+
+---
+
+## Authentication
+
+**Public endpoints** — use the `X-API-Key` header:
+
+```
+X-API-Key: acmedns_your-api-key-here
+```
+
+**Admin endpoints** — use `Authorization: Bearer` with the master key:
+
+```
+Authorization: Bearer your-master-key-here
+```
+
+Both missing and invalid credentials return `401`. The error message does not distinguish between the two cases.
+
+---
+
+## Public Endpoints
+
+### POST /api/register
+
+Register a new domain with acme-dns. The registration allocates a dedicated subdomain for DNS-01 challenge records.
+
+**Request:**
+
+```bash
+curl -X POST https://acmedns.realworld.net.au/api/register \
+  -H "X-API-Key: acmedns_your-api-key-here" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com"}'
+```
+
+Wildcard domains are supported:
+
+```bash
+curl -X POST https://acmedns.realworld.net.au/api/register \
+  -H "X-API-Key: acmedns_your-api-key-here" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "*.example.com"}'
+```
+
+**Response (200):**
+
+```json
+{
+  "subdomain": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "username": "abcdef01-2345-6789-abcd-ef0123456789",
+  "password": "SomeRandomPassword123",
+  "fulldomain": "a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au",
+  "allowfrom": []
+}
+```
+
+The response is proxied directly from acme-dns. **Credentials (`username` and `password`) are only returned once** — store them immediately. They cannot be retrieved again.
+
+For wildcard domains (`*.example.com`), the CNAME record should point `_acme-challenge.example.com` (without the `*.` prefix) to the returned `fulldomain`.
+
+---
+
+### POST /api/lookup
+
+Look up the ACME DNS configuration for a previously registered domain. Returns configuration details and DNS setup instructions, but does **not** return acme-dns username or password.
+
+**Request:**
+
+```bash
+curl -X POST https://acmedns.realworld.net.au/api/lookup \
+  -H "X-API-Key: acmedns_your-api-key-here" \
+  -H "Content-Type: application/json" \
+  -d '{"domain": "example.com"}'
+```
+
+**Response (200):**
+
+```json
+{
+  "domain": "example.com",
+  "acme_dns_server": "acmedns.realworld.net.au",
+  "subdomain": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "cname_record": {
+    "name": "_acme-challenge.example.com",
+    "value": "a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au",
+    "type": "CNAME"
+  },
+  "registration_info": {
+    "registered_at": "2026-03-24T10:00:00",
+    "key_name": "My API Key",
+    "total_registrations": 1
+  },
+  "instructions": {
+    "step1": "Add this CNAME record to your DNS: _acme-challenge.example.com CNAME a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au",
+    "step2": "Configure your ACME client to use DNS-01 challenge with acme-dns",
+    "step3": "Use the subdomain and your API key for certificate requests"
+  }
+}
+```
+
+Returns `404` if no registration exists for the domain under the current API key.
+
+---
+
+### GET /api/health
+
+Health check. Does not require authentication.
+
+**Request:**
+
+```bash
+curl https://acmedns.realworld.net.au/api/health
+```
+
+**Response (200):**
+
+```json
+{
+  "status": "healthy",
+  "database": "ok",
+  "acme_dns": "ok"
+}
+```
+
+`acme_dns` reflects connectivity to the upstream acme-dns service. Returns `500` with `"status": "unhealthy"` if either check fails.
+
+---
+
+### GET /api/info
+
+Returns metadata about the API key making the request. Does not return the key value itself.
+
+**Request:**
+
+```bash
+curl https://acmedns.realworld.net.au/api/info \
+  -H "X-API-Key: acmedns_your-api-key-here"
+```
+
+**Response (200):**
+
+```json
+{
+  "name": "My API Key",
+  "email": "user@example.com",
+  "organization": "Example Org",
+  "created_at": "2026-03-01T09:00:00",
+  "expires_at": "2027-03-01T09:00:00",
+  "usage_count": 42,
+  "last_used_at": "2026-03-24T10:00:00",
+  "registration_count": 5
+}
+```
+
+`expires_at` is `null` for non-expiring keys. `email` and `organization` are `null` if not set at key creation.
+
+---
+
+## Admin Endpoints
+
+All admin endpoints require `Authorization: Bearer <master-key>`.
+
+### POST /api/admin/keys
+
+Create a new API key.
+
+**Request:**
+
+```bash
+curl -X POST https://acmedns.realworld.net.au/api/admin/keys \
+  -H "Authorization: Bearer your-master-key-here" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "My Client",
+    "email": "client@example.com",
+    "organization": "Example Org",
+    "expires_days": 365
+  }'
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Display name for the key |
+| `email` | No | Contact email |
+| `organization` | No | Organisation name |
+| `expires_days` | No | Expiry in days (1–3650). Omit for no expiry. |
+
+**Response (201):**
+
+```json
+{
+  "key_id": "key_a1b2c3d4e5f6a7b8",
+  "api_key": "acmedns_SomeGeneratedKeyValue",
+  "name": "My Client",
+  "expires_at": "2027-03-24T10:00:00",
+  "message": "Store this API key securely - it will not be shown again"
+}
+```
+
+**The `api_key` value is only returned once.** Store it immediately.
+
+---
+
+### GET /api/admin/keys
+
+List all API keys. Actual key values are never returned.
+
+**Request:**
+
+```bash
+curl https://acmedns.realworld.net.au/api/admin/keys \
+  -H "Authorization: Bearer your-master-key-here"
+```
+
+**Response (200):**
+
+```json
+[
+  {
+    "key_id": "key_a1b2c3d4e5f6a7b8",
+    "name": "My Client",
+    "email": "client@example.com",
+    "organization": "Example Org",
+    "created_at": "2026-03-01T09:00:00",
+    "expires_at": "2027-03-01T09:00:00",
+    "is_active": 1,
+    "usage_count": 42,
+    "last_used_at": "2026-03-24T10:00:00"
+  }
+]
+```
+
+---
+
+### DELETE /api/admin/keys/\<key_id\>
+
+Revoke an API key. Sets `is_active` to `0` — does not delete the record.
+
+**Request:**
+
+```bash
+curl -X DELETE https://acmedns.realworld.net.au/api/admin/keys/key_a1b2c3d4e5f6a7b8 \
+  -H "Authorization: Bearer your-master-key-here"
+```
+
+**Response (200):**
+
+```json
+{
+  "message": "API key revoked"
+}
+```
+
+Returns `404` if `key_id` does not exist.
+
+---
+
+### GET /api/admin/registrations
+
+List registrations. Returns the most recent 100 records, ordered by `created_at` descending.
+
+**Request:**
+
+```bash
+curl https://acmedns.realworld.net.au/api/admin/registrations \
+  -H "Authorization: Bearer your-master-key-here"
+```
+
+**Response (200):**
+
+```json
+[
+  {
+    "id": 1,
+    "api_key_id": "key_a1b2c3d4e5f6a7b8",
+    "subdomain": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "domain_hint": "example.com",
+    "client_ip": "203.0.113.10",
+    "created_at": "2026-03-24T10:00:00",
+    "key_name": "My Client",
+    "organization": "Example Org"
+  }
+]
+```
+
+---
+
+### DELETE /api/admin/registrations/\<id\>
+
+Delete a registration record by its integer ID.
+
+**Request:**
+
+```bash
+curl -X DELETE https://acmedns.realworld.net.au/api/admin/registrations/1 \
+  -H "Authorization: Bearer your-master-key-here"
+```
+
+**Response (200):**
+
+```json
+{
+  "message": "Registration revoked successfully"
+}
+```
+
+Returns `404` if the registration ID does not exist.
+
+---
+
+### GET /api/admin/stats
+
+Service statistics.
+
+**Request:**
+
+```bash
+curl https://acmedns.realworld.net.au/api/admin/stats \
+  -H "Authorization: Bearer your-master-key-here"
+```
+
+**Response (200):**
+
+```json
+{
+  "total_keys": 10,
+  "active_keys": 8,
+  "total_registrations": 150,
+  "registrations_last_24h": 3,
+  "top_users": [
+    {
+      "name": "My Client",
+      "organization": "Example Org",
+      "registration_count": 42
+    }
+  ]
+}
+```
+
+`top_users` returns up to 10 entries, ordered by `registration_count` descending.
+
+---
+
+## Rate Limits
+
+Rate limit headers are included in all responses (`X-RateLimit-*`). On breach, the response is `429` with a `retry_after` field (seconds).
+
+| Endpoint | Limit |
+|---|---|
+| `POST /api/register` | 10 / minute |
+| `GET /api/health` | 30 / minute |
+| `GET /api/info` | 30 / minute |
+| `POST /api/lookup` | 20 / minute |
+| `POST /api/admin/keys` | 10 / hour |
+| `GET /api/admin/keys` | 30 / hour |
+| `DELETE /api/admin/keys/<key_id>` | 20 / hour |
+| `GET /api/admin/registrations` | 60 / hour |
+| `DELETE /api/admin/registrations/<id>` | 30 / hour |
+| `GET /api/admin/stats` | 100 / hour |
+| Default (all other routes) | 200 / day, 50 / hour |
+
+---
+
+## Error Responses
+
+All errors return JSON with an `"error"` field.
+
+| Status | Meaning |
+|---|---|
+| `400` | Validation error (invalid domain format, missing required field, out-of-range value) |
+| `401` | Authentication failure — used for both missing and invalid credentials |
+| `404` | Resource not found |
+| `429` | Rate limit exceeded — includes `retry_after` (seconds) |
+| `500` | Internal server error |
+| `503` | Upstream service (acme-dns) unavailable |
+
+Example `429` response:
+
+```json
+{
+  "error": "Rate limit exceeded",
+  "message": "You have exceeded the rate limit. Try again later.",
+  "retry_after": 47
+}
+```
+
+---
+
+## The /update Endpoint
+
+> **Important:** The `/update` endpoint is at the root path — `https://acmedns.realworld.net.au/update` — **not** under `/api/`.
+
+This is the native acme-dns endpoint that ACME clients call directly when performing DNS record updates during challenge validation. It is routed by Traefik straight to the acme-dns service without passing through the registration API.
+
+The `/api/*` registration API is a separate management layer for provisioning and key management. These two layers serve different purposes and must not be confused.

--- a/skills/acmedns/reference/dns-setup.md
+++ b/skills/acmedns/reference/dns-setup.md
@@ -1,0 +1,190 @@
+# RWTS ACME DNS — DNS Setup and CNAME Configuration Reference
+
+**Purpose:** Loaded during registration when users need CNAME configuration help, or when DNS verification fails.
+
+---
+
+## How DNS-01 Delegation Works
+
+DNS-01 challenges let you prove domain ownership by publishing a TXT record under `_acme-challenge.<domain>`. The problem: ACME clients would need write access to your DNS zone for every renewal. Delegation avoids this.
+
+**The delegation chain:**
+
+1. Client registers `example.com` with the ACME DNS service — gets a UUID subdomain (e.g. `a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au`)
+2. Client adds a one-time CNAME in their DNS zone: `_acme-challenge.example.com` → `a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au`
+3. When an ACME client requests a certificate, Let's Encrypt queries `_acme-challenge.example.com`
+4. The CNAME redirects the query to the acme-dns subdomain
+5. acme-dns serves the TXT record containing the challenge token
+6. Challenge passes — certificate issued
+
+**Why this is useful:** The CNAME is set once and never touched again. All future renewals happen automatically through the acme-dns service without requiring any further DNS changes in the client's zone. The ACME client only needs credentials for the acme-dns service, not for the client's DNS provider.
+
+---
+
+## Wildcard Domain Handling
+
+Wildcard certificates (`*.example.com`) use the same `_acme-challenge` prefix as non-wildcard certs. Strip the `*.` prefix when determining the CNAME name.
+
+| Domain requested | CNAME name |
+|---|---|
+| `example.com` | `_acme-challenge.example.com` |
+| `*.example.com` | `_acme-challenge.example.com` |
+| `*.sub.example.com` | `_acme-challenge.sub.example.com` |
+
+**Important:** `example.com` and `*.example.com` are treated as separate domains by the registration service — each requires its own acme-dns registration and gets its own UUID subdomain. However, the CNAME name for both is the same (`_acme-challenge.example.com`).
+
+**SAN certificates covering both base and wildcard:** If requesting a certificate for `example.com` AND `*.example.com` in the same cert, you may need two CNAME records pointing to two different acme-dns subdomains. Not all DNS providers allow two CNAMEs on the same name — check your provider's behaviour. Some ACME clients handle this automatically; others require manual configuration.
+
+---
+
+## CNAME Record Examples
+
+Replace `<subdomain>` with the UUID returned from registration (the `subdomain` field, not including the domain suffix). Replace `example.com` with the actual domain.
+
+### Cloudflare
+
+| Field | Value |
+|---|---|
+| Type | CNAME |
+| Name | `_acme-challenge` |
+| Target | `<subdomain>.acmedns.realworld.net.au` |
+| Proxy status | **DNS only (grey cloud)** |
+
+Cloudflare automatically appends the zone domain to the Name field, so entering `_acme-challenge` results in `_acme-challenge.example.com`.
+
+**The proxy status MUST be set to DNS only (grey cloud).** If the orange cloud (proxied) is enabled, Cloudflare intercepts and proxies the DNS query through their network, which breaks DNS resolution of the CNAME target. Let's Encrypt cannot reach the acme-dns TXT record. This is the most common Cloudflare misconfiguration.
+
+### Route 53
+
+| Field | Value |
+|---|---|
+| Record name | `_acme-challenge.example.com` |
+| Record type | CNAME |
+| Value | `<subdomain>.acmedns.realworld.net.au` |
+| TTL | `300` |
+
+Route 53 requires the full record name including the zone domain.
+
+### Generic Zone File
+
+```
+_acme-challenge.example.com. 300 IN CNAME <subdomain>.acmedns.realworld.net.au.
+```
+
+Note: trailing dots are required in zone file format. They mark names as fully qualified domain names (FQDNs). Without the trailing dot, the DNS server appends the zone name to the target, producing an incorrect record.
+
+---
+
+## TTL Recommendations
+
+- **300 seconds (5 minutes)** is a good default for `_acme-challenge` CNAME records
+- Lower TTL means faster propagation if you need to change the record, but generates more DNS queries
+- If creating a new CNAME, TTL has little impact on initial propagation time — the record just needs to exist before Let's Encrypt queries it
+- If replacing an existing record, the old TTL determines how long caches hold the old value
+
+---
+
+## Verification Commands
+
+After adding the CNAME, verify it resolves correctly before attempting certificate issuance.
+
+**Check the CNAME record exists:**
+
+```bash
+dig CNAME _acme-challenge.example.com
+```
+
+Expected output (relevant section):
+
+```
+;; ANSWER SECTION:
+_acme-challenge.example.com. 300 IN CNAME a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au.
+```
+
+**Check using a specific resolver (bypasses local cache):**
+
+```bash
+dig CNAME _acme-challenge.example.com @8.8.8.8
+```
+
+**Check the TXT record that acme-dns serves (after at least one cert request):**
+
+```bash
+dig TXT a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au
+```
+
+Expected output once a challenge has been set:
+
+```
+;; ANSWER SECTION:
+a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au. 1 IN TXT "challenge-token-value-here"
+```
+
+If this returns `NXDOMAIN` or no answer, either the CNAME is wrong or propagation hasn't completed.
+
+**Trace the full resolution chain:**
+
+```bash
+dig +trace _acme-challenge.example.com
+```
+
+This shows each DNS hop and is useful for diagnosing where resolution breaks.
+
+---
+
+## Common Pitfalls
+
+### Missing trailing dot in zone files
+
+Zone file records use FQDN format. A target without a trailing dot has the zone name appended by the DNS server.
+
+- Wrong: `... CNAME a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au`
+- Correct: `... CNAME a1b2c3d4-e5f6-7890-abcd-ef1234567890.acmedns.realworld.net.au.`
+
+This only applies to raw zone files. Cloudflare, Route 53, and most web-based DNS interfaces handle FQDNs without trailing dots.
+
+---
+
+### Cloudflare proxy enabled on CNAME
+
+The orange cloud (proxied) mode in Cloudflare must not be used on `_acme-challenge` records. When proxied, Cloudflare intercepts DNS queries and returns its own IP addresses rather than following the CNAME. Let's Encrypt then cannot reach the acme-dns TXT record and the challenge fails.
+
+Set the CNAME to DNS only (grey cloud). This applies only to this specific record — other records in the zone can remain proxied.
+
+---
+
+### Propagation delays
+
+DNS changes do not take effect instantly. How long propagation takes depends on:
+
+- **For new records:** Generally 1–5 minutes for most resolvers, but up to several hours for some ISP resolvers
+- **For changed records:** At minimum the TTL of the previous record — if the old TTL was 1 hour, cached resolvers may serve the old value for up to an hour
+
+If `dig @8.8.8.8` shows the correct CNAME but `dig` (using your local resolver) does not, it's a local cache issue. Wait or flush the local DNS cache.
+
+---
+
+### Existing TXT record on `_acme-challenge`
+
+A DNS name cannot have both a CNAME and a TXT record. If there is an existing `_acme-challenge.example.com TXT` record (from a previous manual DNS-01 challenge), the CNAME cannot be added alongside it.
+
+Remove all existing TXT records on `_acme-challenge.example.com` before adding the CNAME.
+
+---
+
+### Subdomain confusion
+
+The registration response contains a `subdomain` field (the UUID) and a `fulldomain` field. These are the **target** of the CNAME, not the name.
+
+- CNAME **name:** `_acme-challenge.example.com` (always this format, based on your domain)
+- CNAME **target:** `<uuid>.acmedns.realworld.net.au` (from the registration response `fulldomain`)
+
+The UUID is not a replacement for `_acme-challenge` — it goes on the right-hand side of the CNAME.
+
+---
+
+### Wrong domain registered for wildcards
+
+For `*.example.com`, register using `*.example.com` (with the asterisk). The registration service strips the `*.` prefix internally when generating the CNAME target, but the domain recorded in the system should match what you pass to your ACME client.
+
+If your ACME client is configured to request `*.example.com` but you registered `example.com`, the credentials will not match and the DNS update will fail.

--- a/skills/acmedns/reference/platforms/acme-sh.md
+++ b/skills/acmedns/reference/platforms/acme-sh.md
@@ -1,0 +1,117 @@
+# acme.sh — RWTS ACME DNS Platform Reference
+
+**Purpose:** Loaded on demand when the user is issuing certificates with acme.sh against the RWTS ACME DNS service.
+
+---
+
+## Prerequisites
+
+- acme.sh installed:
+  ```bash
+  curl https://get.acme.sh | sh -s email=you@example.com
+  ```
+- ACME DNS registration credentials from the RWTS registration service (subdomain, username, password). Obtain these via `POST /api/register` or the admin UI.
+
+---
+
+## Configuration
+
+Set environment variables before running acme.sh. These are saved automatically to `~/.acme.sh/account.conf` after first use and do not need to be re-exported on subsequent runs.
+
+```bash
+export ACMEDNS_UPDATE_URL="https://acmedns.realworld.net.au/update"
+export ACMEDNS_USERNAME="{{USERNAME}}"
+export ACMEDNS_PASSWORD="{{PASSWORD}}"
+export ACMEDNS_SUBDOMAIN="{{SUBDOMAIN}}"
+```
+
+Replace `{{USERNAME}}`, `{{PASSWORD}}`, and `{{SUBDOMAIN}}` with the values returned by the registration endpoint.
+
+> **Important:** `ACMEDNS_UPDATE_URL` must point to `https://acmedns.realworld.net.au/update` (the root `/update` path). Do **not** use `/api/update` — that path does not exist.
+
+> **Note:** Verify these environment variable names against the current acme.sh DNS API docs at `https://github.com/acmesh-official/acme.sh/wiki/dnsapi` — variable names may change between versions.
+
+---
+
+## Issue Certificate
+
+**Single domain:**
+```bash
+acme.sh --issue --dns dns_acmedns -d {{DOMAIN}}
+```
+
+**Domain with wildcard (both bare and wildcard in one certificate):**
+```bash
+acme.sh --issue --dns dns_acmedns -d {{DOMAIN}} -d '*.{{DOMAIN}}'
+```
+
+**Dry run (staging — does not issue a real certificate):**
+```bash
+acme.sh --issue --dns dns_acmedns -d {{DOMAIN}} --staging
+```
+
+---
+
+## Certificate Locations
+
+After issue, certificates are stored in:
+
+```
+~/.acme.sh/{{DOMAIN}}/
+```
+
+| File | Contents |
+|---|---|
+| `{{DOMAIN}}.cer` | Domain certificate |
+| `{{DOMAIN}}.key` | Private key |
+| `ca.cer` | Intermediate CA certificate |
+| `fullchain.cer` | Full chain (domain cert + CA) |
+
+---
+
+## Install Certificate to Web Server
+
+Use `--install-cert` to copy certificates to the appropriate location and reload the web server. Do not reference the `~/.acme.sh/` files directly in production.
+
+**Nginx:**
+```bash
+acme.sh --install-cert -d {{DOMAIN}} \
+  --key-file /etc/nginx/ssl/{{DOMAIN}}.key \
+  --fullchain-file /etc/nginx/ssl/{{DOMAIN}}.pem \
+  --reloadcmd "systemctl reload nginx"
+```
+
+**Apache:**
+```bash
+acme.sh --install-cert -d {{DOMAIN}} \
+  --key-file /etc/apache2/ssl/{{DOMAIN}}.key \
+  --fullchain-file /etc/apache2/ssl/{{DOMAIN}}.pem \
+  --reloadcmd "systemctl reload apache2"
+```
+
+The `--reloadcmd` is run automatically on every renewal.
+
+---
+
+## Renewal
+
+Renewal is fully automatic. acme.sh installs a cron job during installation that runs daily. Certificates are renewed approximately 30 days before expiry. No manual action is required.
+
+---
+
+## Verification
+
+**List all managed certificates:**
+```bash
+acme.sh --list
+```
+
+**Force a manual renewal (for testing):**
+```bash
+acme.sh --renew -d {{DOMAIN}} --force
+```
+
+**Show certificate details:**
+```bash
+acme.sh --info -d {{DOMAIN}}
+```

--- a/skills/acmedns/reference/platforms/apache.md
+++ b/skills/acmedns/reference/platforms/apache.md
@@ -1,0 +1,251 @@
+# RWTS ACME DNS — Apache Platform Reference
+
+**Purpose:** Loaded on demand when the user is configuring Apache with ACME DNS wildcard certificates via certbot.
+
+---
+
+## Prerequisites
+
+- Apache with `mod_ssl` enabled
+- `certbot` installed (via system package manager or pip)
+- `certbot-dns-acmedns` plugin: `pip install certbot-dns-acmedns`
+- acmedns registration credentials for the domain (from `/api/register`)
+- CNAME record added in your DNS zone (see dns-setup reference)
+
+---
+
+## Enable mod_ssl
+
+On Debian/Ubuntu:
+
+```bash
+a2enmod ssl
+systemctl restart apache2
+```
+
+On RHEL/CentOS, `mod_ssl` is typically installed via:
+
+```bash
+dnf install mod_ssl
+systemctl restart httpd
+```
+
+---
+
+## Certbot Credential Files
+
+Both files belong in `/etc/letsencrypt/acmedns/`. Create the directory if it does not exist:
+
+```bash
+mkdir -p /etc/letsencrypt/acmedns
+```
+
+### acmedns.ini
+
+```ini
+dns_acmedns_api_url = https://acmedns.realworld.net.au
+dns_acmedns_registration_file = /etc/letsencrypt/acmedns/acmedns-registration.json
+```
+
+Set permissions:
+
+```bash
+chmod 600 /etc/letsencrypt/acmedns/acmedns.ini
+```
+
+**Important:** `dns_acmedns_api_url` must be `https://acmedns.realworld.net.au` — the root path, **not** `/api/`. The plugin communicates with the native acme-dns `/update` endpoint, which is routed at the root level.
+
+### acmedns-registration.json
+
+```json
+{
+  "{{DOMAIN}}": {
+    "username": "{{USERNAME}}",
+    "password": "{{PASSWORD}}",
+    "fulldomain": "{{FULLDOMAIN}}",
+    "subdomain": "{{SUBDOMAIN}}",
+    "allowfrom": []
+  }
+}
+```
+
+Set permissions:
+
+```bash
+chmod 600 /etc/letsencrypt/acmedns/acmedns-registration.json
+```
+
+Replace the template variables with values from `/api/register`:
+
+| Template variable | Source |
+|---|---|
+| `{{DOMAIN}}` | The domain you are certifying (e.g. `example.com`) |
+| `{{USERNAME}}` | `username` from registration response |
+| `{{PASSWORD}}` | `password` from registration response |
+| `{{FULLDOMAIN}}` | `fulldomain` from registration response |
+| `{{SUBDOMAIN}}` | `subdomain` from registration response |
+
+For wildcard domains registered as `*.{{DOMAIN}}`, use the base domain (without `*.`) as the key, because the CNAME is set on `_acme-challenge.{{DOMAIN}}`.
+
+---
+
+## DNS Prerequisite
+
+Before issuing a certificate, the CNAME record must be in place in your public DNS:
+
+```
+_acme-challenge.{{DOMAIN}}  CNAME  {{FULLDOMAIN}}
+```
+
+Allow time for DNS propagation before running certbot.
+
+---
+
+## Issue Certificate
+
+### Single domain
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}}
+```
+
+### Wildcard + base domain
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}} \
+  -d '*.{{DOMAIN}}'
+```
+
+### Dry run (test without issuing)
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}} \
+  --dry-run
+```
+
+Certificates are stored under `/etc/letsencrypt/live/{{DOMAIN}}/`.
+
+---
+
+## Apache VirtualHost Configuration
+
+### Debian/Ubuntu
+
+Write the VirtualHost config to `/etc/apache2/sites-available/{{DOMAIN}}.conf`:
+
+```apache
+<VirtualHost *:443>
+    ServerName {{DOMAIN}}
+    SSLEngine on
+    SSLCertificateFile /etc/letsencrypt/live/{{DOMAIN}}/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/{{DOMAIN}}/privkey.pem
+    SSLProtocol all -SSLv3 -TLSv1 -TLSv1.1
+    SSLCipherSuite HIGH:!aNULL:!MD5
+    DocumentRoot /var/www/html
+</VirtualHost>
+
+<VirtualHost *:80>
+    ServerName {{DOMAIN}}
+    Redirect permanent / https://{{DOMAIN}}/
+</VirtualHost>
+```
+
+Then enable the site and reload:
+
+```bash
+a2ensite {{DOMAIN}}
+apachectl configtest
+systemctl reload apache2
+```
+
+### RHEL/CentOS
+
+Write the VirtualHost config to `/etc/httpd/conf.d/{{DOMAIN}}.conf` using the same block above, then:
+
+```bash
+apachectl configtest
+systemctl reload httpd
+```
+
+---
+
+## Renewal
+
+Certbot handles renewal automatically via a systemd timer or cron job installed at package time.
+
+### Deploy hook
+
+To reload Apache after each successful renewal, pass a deploy hook:
+
+```bash
+certbot renew --deploy-hook "systemctl reload apache2"
+```
+
+On RHEL/CentOS, replace `apache2` with `httpd`.
+
+### Recommended cron job (if not using systemd timer)
+
+```
+0 0,12 * * * certbot renew --quiet --deploy-hook "systemctl reload apache2"
+```
+
+Runs twice daily. Certbot only renews certificates with fewer than 30 days remaining.
+
+---
+
+## Verification
+
+### Test configuration syntax
+
+```bash
+apachectl configtest
+```
+
+Expected output: `Syntax OK`
+
+### Reload Apache
+
+```bash
+systemctl reload apache2
+```
+
+### Inspect the live certificate
+
+```bash
+echo | openssl s_client -connect {{DOMAIN}}:443 -servername {{DOMAIN}} 2>/dev/null | openssl x509 -noout -dates
+```
+
+Expected output:
+
+```
+notBefore=Mar 24 00:00:00 2026 GMT
+notAfter=Jun 22 23:59:59 2026 GMT
+```
+
+### List all certbot-managed certificates
+
+```bash
+certbot certificates
+```
+
+---
+
+## Common Issues
+
+| Problem | Likely cause |
+|---|---|
+| DNS challenge failed | CNAME record missing or not yet propagated |
+| `certbot-dns-acmedns` plugin not found | Plugin not installed; run `pip install certbot-dns-acmedns` |
+| `No module named certbot_dns_acmedns` | Plugin installed in wrong Python environment |
+| Apache reports `SSLCertificateFile does not exist` | Certificate not yet issued; run certbot first |
+| `AH00526: Syntax error` on reload | Run `apachectl configtest` to identify the offending line |
+| API unreachable | Network issue or `dns_acmedns_api_url` misconfigured |

--- a/skills/acmedns/reference/platforms/caddy.md
+++ b/skills/acmedns/reference/platforms/caddy.md
@@ -1,0 +1,270 @@
+# Caddy — RWTS ACME DNS Platform Reference
+
+**Purpose:** Loaded on demand when the user is configuring Caddy with the RWTS ACME DNS service for automatic TLS.
+
+---
+
+## Prerequisites
+
+- Caddy with the `caddy-dns/acmedns` DNS module — requires a custom build (not included in the standard Caddy binary)
+- `xcaddy` build tool
+- acmedns registration credentials (username, password, fulldomain, subdomain) — obtain via `POST /api/register` or the admin UI
+- CNAME record added in your DNS zone (see dns-setup reference)
+
+> **Module availability note:** The `caddy-dns/acmedns` module may not always be actively maintained. Before building, check the [caddy-dns GitHub org](https://github.com/caddy-dns) for current status and the latest module path. If the module is unavailable or stale, use the [LEGO fallback](#fallback-lego-acme-dns-provider) described at the bottom of this file.
+
+---
+
+## Build Caddy with the acmedns DNS Module
+
+Install `xcaddy` and build a custom Caddy binary:
+
+```bash
+go install github.com/caddyserver/xcaddy/cmd/xcaddy@latest
+xcaddy build --with github.com/caddy-dns/acmedns
+```
+
+This produces a `caddy` binary in the current directory. Replace the system binary or install it:
+
+```bash
+sudo mv caddy /usr/bin/caddy
+sudo setcap cap_net_bind_service=+ep /usr/bin/caddy
+```
+
+Verify the module is present:
+
+```bash
+caddy list-modules | grep acmedns
+```
+
+---
+
+## Configuration Files
+
+### Caddyfile
+
+Place the Caddyfile at `/etc/caddy/Caddyfile`.
+
+**Single domain:**
+
+```
+{{DOMAIN}} {
+    tls {
+        dns acmedns {
+            server_url https://acmedns.realworld.net.au
+            registration /etc/caddy/acmedns-registration.json
+        }
+    }
+    reverse_proxy localhost:8080
+}
+```
+
+**Wildcard domain (covers `*.{{DOMAIN}}`):**
+
+```
+*.{{DOMAIN}} {
+    tls {
+        dns acmedns {
+            server_url https://acmedns.realworld.net.au
+            registration /etc/caddy/acmedns-registration.json
+        }
+    }
+    @match host {args[0]}.{{DOMAIN}}
+    handle @match {
+        reverse_proxy localhost:8080
+    }
+}
+```
+
+**Wildcard plus base domain (both in one block):**
+
+```
+{{DOMAIN}} *.{{DOMAIN}} {
+    tls {
+        dns acmedns {
+            server_url https://acmedns.realworld.net.au
+            registration /etc/caddy/acmedns-registration.json
+        }
+    }
+    reverse_proxy localhost:8080
+}
+```
+
+> **Important:** `server_url` must be `https://acmedns.realworld.net.au` — the root path, **not** `/api/`. The module communicates with the native acme-dns `/update` endpoint routed at the root level.
+
+---
+
+### acmedns-registration.json
+
+Place this file at the path referenced in `registration` (e.g. `/etc/caddy/acmedns-registration.json`).
+
+**Single domain:**
+
+```json
+{
+  "{{DOMAIN}}": {
+    "username": "{{USERNAME}}",
+    "password": "{{PASSWORD}}",
+    "fulldomain": "{{FULLDOMAIN}}",
+    "subdomain": "{{SUBDOMAIN}}",
+    "allowfrom": []
+  }
+}
+```
+
+**Wildcard plus base domain (separate registrations):**
+
+```json
+{
+  "{{DOMAIN}}": {
+    "username": "{{USERNAME_BASE}}",
+    "password": "{{PASSWORD_BASE}}",
+    "fulldomain": "{{FULLDOMAIN_BASE}}",
+    "subdomain": "{{SUBDOMAIN_BASE}}",
+    "allowfrom": []
+  },
+  "*.{{DOMAIN}}": {
+    "username": "{{USERNAME_WILDCARD}}",
+    "password": "{{PASSWORD_WILDCARD}}",
+    "fulldomain": "{{FULLDOMAIN_WILDCARD}}",
+    "subdomain": "{{SUBDOMAIN_WILDCARD}}",
+    "allowfrom": []
+  }
+}
+```
+
+Replace template variables with values returned by `/api/register`:
+
+| Variable | Description | Example |
+|---|---|---|
+| `{{DOMAIN}}` | The domain being certified | `example.com` |
+| `{{USERNAME}}` | acmedns account username (UUID) | `a1b2c3d4-...` |
+| `{{PASSWORD}}` | acmedns account password | `...` |
+| `{{FULLDOMAIN}}` | Full CNAME target from registration | `a1b2c3d4-....acmedns.realworld.net.au` |
+| `{{SUBDOMAIN}}` | Subdomain component of fulldomain | `a1b2c3d4-...` |
+
+Set strict permissions on the file — it contains credentials:
+
+```bash
+chmod 600 /etc/caddy/acmedns-registration.json
+chown caddy:caddy /etc/caddy/acmedns-registration.json
+```
+
+Do not commit this file to version control.
+
+---
+
+## Where to Put Each File
+
+| File | Location | Notes |
+|---|---|---|
+| `Caddyfile` | `/etc/caddy/Caddyfile` | Main Caddy configuration |
+| `acmedns-registration.json` | Path set in `registration` directive | Readable by Caddy process; `chmod 600` |
+
+---
+
+## DNS Prerequisite
+
+Before Caddy can issue a certificate, the CNAME record must be in place on your public DNS:
+
+```
+_acme-challenge.{{DOMAIN}}  CNAME  {{FULLDOMAIN}}
+```
+
+Allow time for DNS propagation before starting Caddy or reloading the config.
+
+---
+
+## Renewal
+
+Renewal is fully automatic. Caddy monitors certificate expiry and renews certificates internally before they expire. No cron job, systemd timer, or manual intervention is required.
+
+---
+
+## Verification
+
+Validate the Caddyfile syntax before reloading:
+
+```bash
+caddy validate --config /etc/caddy/Caddyfile
+```
+
+Confirm the issued certificate subject after Caddy has started:
+
+```bash
+curl -v https://{{DOMAIN}} 2>&1 | grep "subject:"
+```
+
+Inspect certificate dates and subject directly:
+
+```bash
+echo | openssl s_client -connect {{DOMAIN}}:443 -servername {{DOMAIN}} 2>/dev/null | openssl x509 -noout -dates -subject
+```
+
+Check Caddy logs for ACME activity:
+
+```bash
+journalctl -u caddy -f | grep -i "acme\|certificate\|tls"
+```
+
+---
+
+## Common Issues
+
+| Problem | Likely cause |
+|---|---|
+| `unknown module: dns.providers.acmedns` | Custom build was not done with `xcaddy`, or build used wrong module path |
+| DNS challenge failed | CNAME record missing, not yet propagated, or `server_url` is wrong |
+| `registration` file not readable | File permissions or path mismatch between Caddyfile and actual file location |
+| Certificate issued for wrong domain | Key in `acmedns-registration.json` does not match the domain Caddy is requesting |
+| `server_url` 404 errors | URL contains `/api/` suffix — use root path only |
+
+---
+
+## Fallback: LEGO acme-dns Provider
+
+If the `caddy-dns/acmedns` module is unavailable or unmaintained, Caddy can delegate DNS challenges to an external ACME solver using the [LEGO](https://go-acme.github.io/lego/) client. This approach uses an external process to handle the DNS-01 challenge and writes the certificate to disk, which Caddy can then reference.
+
+### Install LEGO
+
+```bash
+# Download the latest release from https://github.com/go-acme/lego/releases
+# Example for Linux amd64:
+curl -LO https://github.com/go-acme/lego/releases/latest/download/lego_linux_amd64.tar.gz
+tar xzf lego_linux_amd64.tar.gz
+sudo mv lego /usr/local/bin/lego
+```
+
+### Issue certificate with LEGO using acme-dns provider
+
+```bash
+export ACME_DNS_API_BASE="https://acmedns.realworld.net.au"
+export ACME_DNS_STORAGE_PATH="/etc/caddy/acmedns-registration.json"
+
+lego \
+  --email you@example.com \
+  --dns acme-dns \
+  --domains {{DOMAIN}} \
+  --domains '*.{{DOMAIN}}' \
+  --path /etc/lego \
+  run
+```
+
+### Reference the certificate in Caddyfile
+
+```
+{{DOMAIN}} *.{{DOMAIN}} {
+    tls /etc/lego/certificates/{{DOMAIN}}.crt /etc/lego/certificates/{{DOMAIN}}.key
+    reverse_proxy localhost:8080
+}
+```
+
+### Renewal with LEGO
+
+Replace `run` with `renew` in the LEGO command and add a cron job:
+
+```
+0 0,12 * * * ACME_DNS_API_BASE=https://acmedns.realworld.net.au ACME_DNS_STORAGE_PATH=/etc/caddy/acmedns-registration.json lego --email you@example.com --dns acme-dns --domains {{DOMAIN}} --domains '*.{{DOMAIN}}' --path /etc/lego renew --renew-hook "systemctl reload caddy"
+```
+
+The `--renew-hook` reloads Caddy after each successful renewal so it picks up the new certificate.

--- a/skills/acmedns/reference/platforms/certbot.md
+++ b/skills/acmedns/reference/platforms/certbot.md
@@ -1,0 +1,168 @@
+# Certbot — RWTS ACME DNS Platform Reference
+
+**Purpose:** Loaded on demand when the user is configuring Certbot with the RWTS ACME DNS service.
+
+---
+
+## Prerequisites
+
+- `certbot` installed (via system package manager or pip)
+- `certbot-dns-acmedns` plugin: `pip install certbot-dns-acmedns`
+- An acmedns registration for the domain (credentials from `/api/register`)
+
+---
+
+## Configuration Files
+
+Both files belong in `/etc/letsencrypt/acmedns/`. Create the directory if it does not exist:
+
+```bash
+mkdir -p /etc/letsencrypt/acmedns
+```
+
+### acmedns.ini
+
+```ini
+dns_acmedns_api_url = https://acmedns.realworld.net.au
+dns_acmedns_registration_file = /etc/letsencrypt/acmedns/acmedns-registration.json
+```
+
+Set permissions:
+
+```bash
+chmod 600 /etc/letsencrypt/acmedns/acmedns.ini
+```
+
+**Important:** `dns_acmedns_api_url` must be `https://acmedns.realworld.net.au` — the root path, **not** `/api/`. The plugin communicates directly with the native acme-dns `/update` endpoint, which is routed at the root level, not under `/api/`.
+
+### acmedns-registration.json
+
+```json
+{
+  "{{DOMAIN}}": {
+    "username": "{{USERNAME}}",
+    "password": "{{PASSWORD}}",
+    "fulldomain": "{{FULLDOMAIN}}",
+    "subdomain": "{{SUBDOMAIN}}",
+    "allowfrom": []
+  }
+}
+```
+
+Replace the template variables with the values returned by `/api/register`:
+
+| Template variable | Source |
+|---|---|
+| `{{DOMAIN}}` | The domain you registered (e.g. `example.com`) |
+| `{{USERNAME}}` | `username` from registration response |
+| `{{PASSWORD}}` | `password` from registration response |
+| `{{FULLDOMAIN}}` | `fulldomain` from registration response |
+| `{{SUBDOMAIN}}` | `subdomain` from registration response |
+
+Set permissions:
+
+```bash
+chmod 600 /etc/letsencrypt/acmedns/acmedns-registration.json
+```
+
+For wildcard domains registered as `*.{{DOMAIN}}`, the key in the JSON file should be the base domain without the `*.` prefix (i.e. `{{DOMAIN}}`), because the CNAME record is set on `_acme-challenge.{{DOMAIN}}`.
+
+---
+
+## DNS Prerequisite
+
+Before issuing a certificate, the CNAME record must be in place on your public DNS:
+
+```
+_acme-challenge.{{DOMAIN}}  CNAME  {{FULLDOMAIN}}
+```
+
+Allow time for DNS propagation before proceeding.
+
+---
+
+## Issue Certificate
+
+### Single domain
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}}
+```
+
+### Wildcard + base domain
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}} \
+  -d '*.{{DOMAIN}}'
+```
+
+### Dry run (test without issuing)
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}} \
+  --dry-run
+```
+
+---
+
+## Certificate Location
+
+Issued certificates are stored under `/etc/letsencrypt/live/{{DOMAIN}}/`:
+
+| File | Purpose |
+|---|---|
+| `fullchain.pem` | Certificate + intermediates (use this for most services) |
+| `privkey.pem` | Private key |
+| `cert.pem` | Certificate only |
+| `chain.pem` | Intermediates only |
+
+---
+
+## Renewal
+
+`certbot renew` handles renewal automatically. The acmedns plugin is invoked for each renewal using the stored credentials.
+
+### Manual renewal trigger
+
+```bash
+certbot renew
+```
+
+### Recommended cron job
+
+```
+0 0,12 * * * certbot renew --quiet
+```
+
+This runs twice daily (midnight and noon). Let's Encrypt certificates expire after 90 days; certbot only renews when fewer than 30 days remain.
+
+---
+
+## Verification
+
+### Test renewal without issuing
+
+```bash
+certbot renew --dry-run
+```
+
+### List all managed certificates
+
+```bash
+certbot certificates
+```
+
+### Inspect certificate dates and subject
+
+```bash
+openssl x509 -in /etc/letsencrypt/live/{{DOMAIN}}/fullchain.pem -noout -dates -subject
+```

--- a/skills/acmedns/reference/platforms/haproxy.md
+++ b/skills/acmedns/reference/platforms/haproxy.md
@@ -1,0 +1,259 @@
+# HAProxy — RWTS ACME DNS Platform Reference
+
+**Purpose:** Loaded on demand when the user is configuring HAProxy with the RWTS ACME DNS service. HAProxy does not handle ACME challenges natively — certificates are issued via certbot or acme.sh with a deploy hook that formats them for HAProxy.
+
+---
+
+## Prerequisites
+
+- HAProxy 2.x or later installed
+- certbot (with `certbot-dns-acmedns` plugin) **or** acme.sh installed
+- An acmedns registration for each domain (credentials from `/api/register`):
+  - `{{SUBDOMAIN}}` — UUID returned by `/api/register`
+  - `{{USERNAME}}` — acme-dns account username
+  - `{{PASSWORD}}` — acme-dns account password
+  - `{{FULLDOMAIN}}` — `{{SUBDOMAIN}}.acmedns.realworld.net.au`
+- CNAME record added in your DNS zone (see dns-setup reference)
+- Certificate directory created and secured:
+  ```bash
+  mkdir -p /etc/haproxy/certs
+  chmod 700 /etc/haproxy/certs
+  ```
+
+---
+
+## How It Works
+
+HAProxy reads TLS certificates from a directory or a single combined PEM file. The combined PEM must contain the full certificate chain followed by the private key — HAProxy does not accept them as separate files.
+
+The workflow is:
+
+1. certbot or acme.sh issues a certificate via the acme-dns DNS-01 challenge
+2. A deploy hook (certbot) or `--reloadcmd` (acme.sh) concatenates the cert chain and private key into a single PEM file under `/etc/haproxy/certs/`
+3. HAProxy is reloaded to pick up the new or renewed certificate
+
+---
+
+## Option A: certbot + Deploy Hook
+
+### certbot credentials
+
+Install the plugin and configure credentials (see the certbot platform reference for full details):
+
+```bash
+pip install certbot-dns-acmedns
+mkdir -p /etc/letsencrypt/acmedns
+```
+
+`/etc/letsencrypt/acmedns/acmedns.ini`:
+```ini
+dns_acmedns_api_url = https://acmedns.realworld.net.au
+dns_acmedns_registration_file = /etc/letsencrypt/acmedns/acmedns-registration.json
+```
+
+`/etc/letsencrypt/acmedns/acmedns-registration.json`:
+```json
+{
+  "{{DOMAIN}}": {
+    "username": "{{USERNAME}}",
+    "password": "{{PASSWORD}}",
+    "fulldomain": "{{FULLDOMAIN}}",
+    "subdomain": "{{SUBDOMAIN}}",
+    "allowfrom": []
+  }
+}
+```
+
+Set permissions:
+```bash
+chmod 600 /etc/letsencrypt/acmedns/acmedns.ini
+chmod 600 /etc/letsencrypt/acmedns/acmedns-registration.json
+```
+
+### Deploy hook
+
+Create `/usr/local/bin/haproxy-deploy-cert.sh`:
+
+```bash
+#!/bin/bash
+DOMAIN="${RENEWED_LINEAGE##*/}"
+cat "${RENEWED_LINEAGE}/fullchain.pem" "${RENEWED_LINEAGE}/privkey.pem" \
+  > "/etc/haproxy/certs/${DOMAIN}.pem"
+chmod 600 "/etc/haproxy/certs/${DOMAIN}.pem"
+systemctl reload haproxy
+```
+
+Make it executable:
+```bash
+chmod +x /usr/local/bin/haproxy-deploy-cert.sh
+```
+
+`RENEWED_LINEAGE` is set automatically by certbot to the path of the renewed certificate lineage (e.g. `/etc/letsencrypt/live/example.com`). The script extracts the domain name from the last path component.
+
+### Issue certificate
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}} \
+  --deploy-hook '/usr/local/bin/haproxy-deploy-cert.sh'
+```
+
+For wildcard + base domain:
+
+```bash
+certbot certonly \
+  --authenticator dns-acmedns \
+  --dns-acmedns-credentials /etc/letsencrypt/acmedns/acmedns.ini \
+  -d {{DOMAIN}} \
+  -d '*.{{DOMAIN}}' \
+  --deploy-hook '/usr/local/bin/haproxy-deploy-cert.sh'
+```
+
+The deploy hook runs automatically on every successful renewal.
+
+---
+
+## Option B: acme.sh
+
+Configure acme.sh environment variables (saved to `~/.acme.sh/account.conf` after first use):
+
+```bash
+export ACMEDNS_UPDATE_URL="https://acmedns.realworld.net.au/update"
+export ACMEDNS_USERNAME="{{USERNAME}}"
+export ACMEDNS_PASSWORD="{{PASSWORD}}"
+export ACMEDNS_SUBDOMAIN="{{SUBDOMAIN}}"
+```
+
+Issue the certificate:
+
+```bash
+acme.sh --issue --dns dns_acmedns -d {{DOMAIN}}
+```
+
+Install to HAProxy (creates the combined PEM and reloads HAProxy on every renewal):
+
+```bash
+acme.sh --install-cert -d {{DOMAIN}} \
+  --fullchain-file /etc/haproxy/certs/{{DOMAIN}}.pem \
+  --key-file /etc/haproxy/certs/{{DOMAIN}}.key \
+  --reloadcmd "cat /etc/haproxy/certs/{{DOMAIN}}.pem /etc/haproxy/certs/{{DOMAIN}}.key \
+    > /etc/haproxy/certs/{{DOMAIN}}-combined.pem \
+    && chmod 600 /etc/haproxy/certs/{{DOMAIN}}-combined.pem \
+    && systemctl reload haproxy"
+```
+
+Point HAProxy at `{{DOMAIN}}-combined.pem` (see HAProxy configuration below).
+
+---
+
+## HAProxy Configuration
+
+Add TLS to the `haproxy.cfg` frontend. HAProxy loads all `.pem` files from a directory automatically when you specify a directory path in the `crt` directive.
+
+```
+frontend https
+    bind *:443 ssl crt /etc/haproxy/certs/
+    default_backend app
+
+frontend http
+    bind *:80
+    redirect scheme https code 301
+
+backend app
+    server app1 127.0.0.1:8080 check
+```
+
+| Directive | Notes |
+|---|---|
+| `crt /etc/haproxy/certs/` | Directory — HAProxy loads all `.pem` files found here |
+| `redirect scheme https code 301` | Redirects all HTTP traffic to HTTPS |
+| `server app1 127.0.0.1:8080 check` | Upstream backend; adjust address and port to match your application |
+
+For a single certificate file rather than a directory:
+
+```
+bind *:443 ssl crt /etc/haproxy/certs/{{DOMAIN}}.pem
+```
+
+---
+
+## File Locations
+
+| File | Location | Notes |
+|---|---|---|
+| HAProxy config | `/etc/haproxy/haproxy.cfg` | Add `frontend` and `backend` blocks here |
+| Combined certificate PEM | `/etc/haproxy/certs/{{DOMAIN}}.pem` | `fullchain.pem` + `privkey.pem` concatenated |
+| Certbot credentials | `/etc/letsencrypt/acmedns/` | Keep outside version control |
+| Deploy hook | `/usr/local/bin/haproxy-deploy-cert.sh` | Must be executable |
+
+---
+
+## Renewal
+
+**certbot:** The deploy hook is stored with the certificate lineage and runs automatically on every successful `certbot renew`. Add a cron job if one is not already present:
+
+```
+0 0,12 * * * certbot renew --quiet
+```
+
+**acme.sh:** Renewal is fully automatic via the cron job installed by acme.sh. The `--reloadcmd` registered with `--install-cert` runs automatically on each renewal.
+
+---
+
+## Verification
+
+Validate HAProxy configuration before reloading:
+
+```bash
+haproxy -c -f /etc/haproxy/haproxy.cfg
+```
+
+Reload HAProxy:
+
+```bash
+systemctl reload haproxy
+```
+
+Inspect the certificate served on port 443:
+
+```bash
+echo | openssl s_client -connect {{DOMAIN}}:443 -servername {{DOMAIN}} 2>/dev/null \
+  | openssl x509 -noout -dates -subject
+```
+
+Expected output (Let's Encrypt certificate):
+
+```
+notBefore=Mar 24 00:00:00 2026 GMT
+notAfter=Jun 22 23:59:59 2026 GMT
+subject=CN={{DOMAIN}}
+```
+
+---
+
+## Common Issues
+
+### HAProxy fails to start after cert update
+
+- Ensure the combined PEM contains `fullchain.pem` first, then `privkey.pem` — reversing the order causes a parse error
+- Confirm permissions: the file must be readable by the HAProxy process user (typically `root` or `haproxy`)
+- Run `haproxy -c -f /etc/haproxy/haproxy.cfg` to identify config errors before reloading
+
+### Deploy hook not running on renewal
+
+- certbot only runs deploy hooks when a certificate is actually renewed (not on dry runs)
+- Test the hook manually: `RENEWED_LINEAGE=/etc/letsencrypt/live/{{DOMAIN}} /usr/local/bin/haproxy-deploy-cert.sh`
+- Confirm the hook is executable: `ls -l /usr/local/bin/haproxy-deploy-cert.sh`
+
+### Certificate not being issued
+
+- Confirm the CNAME record is resolving: `dig CNAME _acme-challenge.{{DOMAIN}}`
+- Confirm acmedns credentials are correct and the registration file permissions are `600`
+- Run with `--dry-run` (certbot) or `--staging` (acme.sh) to test without consuming rate limits
+
+### HAProxy serving old certificate after renewal
+
+- The deploy hook or `--reloadcmd` must call `systemctl reload haproxy` (not `restart`) — a reload is sufficient and avoids dropping existing connections
+- Confirm the hook actually ran: check `journalctl -u certbot` or `~/.acme.sh/acme.sh.log`

--- a/skills/acmedns/reference/platforms/nginx-proxy-manager.md
+++ b/skills/acmedns/reference/platforms/nginx-proxy-manager.md
@@ -1,0 +1,110 @@
+# RWTS ACME DNS — Nginx Proxy Manager Platform Reference
+
+**Purpose:** Loaded on demand when the user is configuring ACME DNS wildcard certificates with Nginx Proxy Manager (NPM).
+
+---
+
+## Prerequisites
+
+- Nginx Proxy Manager installed and running
+- Admin access to NPM web interface
+- acmedns registration credentials (username, password, fulldomain, subdomain) — obtain these by registering a domain via the RWTS ACME DNS registration API
+
+---
+
+## Configuration — via NPM web interface
+
+1. Navigate to **SSL Certificates** → **Add SSL Certificate** → **Let's Encrypt**
+2. Enter domain(s): `{{DOMAIN}}` (and `*.{{DOMAIN}}` for wildcard)
+3. Enable **"Use a DNS Challenge"**
+4. Select DNS Provider: **Acme-DNS** (if available) or use **Custom**
+5. If using Custom, set the Credentials File Content to:
+
+```ini
+dns_acmedns_api_url = https://acmedns.realworld.net.au
+dns_acmedns_registration_file = /data/acmedns-registration.json
+```
+
+6. Upload or create the registration JSON file in the NPM data directory (see below)
+
+---
+
+## Configuration — acmedns-registration.json
+
+Create a file with the following structure, using the credentials from your acmedns registration:
+
+```json
+{
+  "{{DOMAIN}}": {
+    "username": "{{USERNAME}}",
+    "password": "{{PASSWORD}}",
+    "fulldomain": "{{FULLDOMAIN}}",
+    "subdomain": "{{SUBDOMAIN}}",
+    "allowfrom": []
+  }
+}
+```
+
+**Template variable reference:**
+
+| Variable | Description | Example |
+|---|---|---|
+| `{{DOMAIN}}` | The domain being certified | `example.com` |
+| `{{USERNAME}}` | acmedns account username (UUID) | `a1b2c3d4-...` |
+| `{{PASSWORD}}` | acmedns account password | `...` |
+| `{{FULLDOMAIN}}` | Full CNAME target provided at registration | `a1b2c3d4-....acmedns.realworld.net.au` |
+| `{{SUBDOMAIN}}` | Subdomain component of fulldomain | `a1b2c3d4-...` |
+
+**Placement:** The file must be accessible at `/data/acmedns-registration.json` inside the NPM container.
+
+If running NPM via Docker, mount the file into the container:
+
+```yaml
+volumes:
+  - ./acmedns-registration.json:/data/acmedns-registration.json:ro
+```
+
+---
+
+## DNS CNAME Setup
+
+Before requesting the certificate, create the required CNAME record in your DNS provider:
+
+```
+_acme-challenge.{{DOMAIN}}  CNAME  {{FULLDOMAIN}}
+```
+
+For wildcard certificates covering both `{{DOMAIN}}` and `*.{{DOMAIN}}`, a single CNAME on `_acme-challenge.{{DOMAIN}}` is sufficient.
+
+---
+
+## Renewal
+
+NPM handles certificate renewal automatically. No manual intervention is required as long as:
+
+- The `acmedns-registration.json` file remains in place and readable
+- The CNAME record remains in DNS
+- NPM has network access to `https://acmedns.realworld.net.au`
+
+Check the **SSL Certificates** page periodically to confirm upcoming renewals complete successfully.
+
+---
+
+## Verification
+
+After the certificate is issued, the **SSL Certificates** page status should show **Valid**.
+
+If the certificate request or renewal fails:
+
+```bash
+docker compose logs npm
+```
+
+Common issues:
+
+| Problem | Likely cause |
+|---|---|
+| DNS challenge failed | CNAME record missing or not yet propagated |
+| Credentials file not found | Volume mount incorrect or file not at `/data/acmedns-registration.json` |
+| API unreachable | Network issue or `dns_acmedns_api_url` misconfigured |
+| Invalid credentials | Username/password in registration JSON do not match acmedns account |

--- a/skills/acmedns/reference/platforms/proxmox.md
+++ b/skills/acmedns/reference/platforms/proxmox.md
@@ -1,0 +1,158 @@
+# Proxmox VE — RWTS ACME DNS Platform Reference
+
+**Purpose:** Loaded on demand when the user is configuring Proxmox VE to obtain Let's Encrypt certificates via the RWTS ACME DNS service.
+
+---
+
+## Prerequisites
+
+- Proxmox VE 7.x or 8.x
+- Shell access to the Proxmox host (or access to the web GUI)
+- acmedns registration credentials for the domain:
+  - `{{USERNAME}}` — acme-dns account username
+  - `{{PASSWORD}}` — acme-dns account password
+  - `{{SUBDOMAIN}}` — UUID returned by `/api/register`
+  - `{{FULLDOMAIN}}` — `{{SUBDOMAIN}}.acmedns.realworld.net.au`
+- CNAME record added in your DNS zone (see dns-setup reference)
+
+---
+
+## Configuration — Web GUI
+
+### 1. Add a Let's Encrypt account (if not already done)
+
+1. Navigate to **Datacenter → ACME**
+2. Under **Accounts**, click **Add**
+3. Enter a name (e.g. `default`) and your email address
+4. Accept the Let's Encrypt Terms of Service and save
+
+### 2. Add the acme-dns challenge plugin
+
+1. Still on **Datacenter → ACME**, go to the **Challenge Plugins** section
+2. Click **Add**
+3. Fill in the fields:
+   - **Plugin ID:** `acmedns`
+   - **API:** select `acme-dns` from the dropdown
+   - **API Data:**
+     ```
+     ACMEDNS_UPDATE_URL=https://acmedns.realworld.net.au/update
+     ACMEDNS_USERNAME={{USERNAME}}
+     ACMEDNS_PASSWORD={{PASSWORD}}
+     ACMEDNS_SUBDOMAIN={{SUBDOMAIN}}
+     ```
+4. Click **Add** to save
+
+### 3. Configure the node certificate
+
+1. Navigate to **Node → System → Certificates**
+2. Under the **ACME** section, click **Add**
+3. Set:
+   - **Challenge Type:** `DNS`
+   - **Plugin:** `acmedns`
+   - **Domain:** `{{DOMAIN}}`
+4. Click **Add**, then click **Order Certificates Now**
+
+Proxmox will call the acme-dns `/update` endpoint, wait for propagation, and retrieve the certificate. The web interface reloads automatically once the certificate is issued.
+
+---
+
+## Configuration — CLI
+
+### Register the acme-dns plugin
+
+```bash
+pvenode acme plugin add dns acmedns \
+  --api acme-dns \
+  --data "ACMEDNS_UPDATE_URL=https://acmedns.realworld.net.au/update,ACMEDNS_USERNAME={{USERNAME}},ACMEDNS_PASSWORD={{PASSWORD}},ACMEDNS_SUBDOMAIN={{SUBDOMAIN}}"
+```
+
+### Register a Let's Encrypt account (if not already done)
+
+```bash
+pvenode acme account register default your-email@example.com
+```
+
+### Order the certificate
+
+```bash
+pvenode acme cert order --domain {{DOMAIN}} --plugin acmedns
+```
+
+Proxmox will contact Let's Encrypt, perform the DNS-01 challenge via the acme-dns plugin, and install the certificate.
+
+---
+
+## Plugin Configuration Storage
+
+The plugin definition is stored in `/etc/pve/acme/plugins.cfg`. This file is managed by Proxmox — edit it via the GUI or `pvenode` CLI rather than directly.
+
+---
+
+## Important: Update URL
+
+`ACMEDNS_UPDATE_URL` must be set to:
+
+```
+https://acmedns.realworld.net.au/update
+```
+
+Use the root `/update` path exactly. Do **not** use `/api/update` — that path does not exist on this service.
+
+---
+
+## Renewal
+
+Renewal is fully automatic. Proxmox installs a systemd timer (`pvenode-acme-cert-renew.timer`) that checks certificate expiry and renews before expiry. No manual action is required.
+
+To check the timer status:
+
+```bash
+systemctl status pvenode-acme-cert-renew.timer
+```
+
+---
+
+## Verification
+
+### GUI
+
+Navigate to **Node → System → Certificates**. The certificate entry shows its status (`Valid`) and the expiry date.
+
+### CLI
+
+**View certificate details:**
+
+```bash
+pvenode acme cert info
+```
+
+**Force a manual renewal (for testing):**
+
+```bash
+pvenode acme cert renew
+```
+
+**Inspect the installed certificate directly:**
+
+```bash
+openssl x509 -in /etc/pve/local/pve-ssl.pem -noout -dates -subject
+```
+
+---
+
+## Common Issues
+
+### Challenge fails with connection error
+
+- Confirm `ACMEDNS_UPDATE_URL` is `https://acmedns.realworld.net.au/update` with no trailing slash and no `/api/` prefix
+- Confirm the Proxmox host can reach `acmedns.realworld.net.au` over HTTPS (check firewall rules)
+
+### Certificate not trusted by browsers
+
+- Confirm the CNAME record is in place: `_acme-challenge.{{DOMAIN}} CNAME {{FULLDOMAIN}}`
+- Run `dig CNAME _acme-challenge.{{DOMAIN}}` to verify propagation before ordering
+
+### Plugin not listed in GUI dropdown
+
+- Confirm the plugin was added with `pvenode acme plugin add` or via the GUI — the dropdown only shows saved plugins
+- Run `pvenode acme plugin list` to verify the plugin exists

--- a/skills/acmedns/reference/platforms/traefik.md
+++ b/skills/acmedns/reference/platforms/traefik.md
@@ -1,0 +1,305 @@
+# RWTS ACME DNS — Traefik Platform Reference
+
+**Purpose:** Loaded when the user chooses Traefik as their ACME client platform. Covers Docker Compose configuration via container labels and command args, credential file setup, and verification.
+
+---
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- Traefik v3.x running as reverse proxy
+- acmedns registration credentials for each domain:
+  - `{{SUBDOMAIN}}` — UUID returned by `/api/register`
+  - `{{USERNAME}}` — acme-dns account username
+  - `{{PASSWORD}}` — acme-dns account password
+  - `{{FULLDOMAIN}}` — `{{SUBDOMAIN}}.acmedns.realworld.net.au`
+- CNAME record added in your DNS zone (see dns-setup reference)
+
+---
+
+## How It Works
+
+Traefik has a built-in `acme-dns` DNS challenge provider. When a router label requests a certificate, Traefik:
+
+1. Calls the acme-dns `/update` endpoint with the DNS-01 challenge token
+2. Uses the configured `resolvers` to check DNS propagation
+3. Notifies Let's Encrypt to verify the challenge
+4. Stores the issued certificate in `acme.json`
+
+Credentials for each domain are read from a JSON file (`acmedns.json`) mounted into the Traefik container. No plugin or external hook is required.
+
+---
+
+## Configuration
+
+Traefik's static configuration (entrypoints, certificate resolvers) is defined via command-line flags on the Traefik container. Per-service routing is configured via Docker container labels. This avoids maintaining a separate `traefik.yml` file.
+
+### acmedns.json (credential file)
+
+This file maps each domain to its acme-dns credentials. The key is the domain name exactly as Traefik will request the certificate for it.
+
+**Single domain:**
+
+```json
+{
+  "{{DOMAIN}}": {
+    "username": "{{USERNAME}}",
+    "password": "{{PASSWORD}}",
+    "fulldomain": "{{FULLDOMAIN}}",
+    "subdomain": "{{SUBDOMAIN}}",
+    "allowfrom": []
+  }
+}
+```
+
+**Wildcard plus base domain (separate registrations, separate entries):**
+
+```json
+{
+  "example.com": {
+    "username": "{{USERNAME_BASE}}",
+    "password": "{{PASSWORD_BASE}}",
+    "fulldomain": "{{FULLDOMAIN_BASE}}",
+    "subdomain": "{{SUBDOMAIN_BASE}}",
+    "allowfrom": []
+  },
+  "*.example.com": {
+    "username": "{{USERNAME_WILDCARD}}",
+    "password": "{{PASSWORD_WILDCARD}}",
+    "fulldomain": "{{FULLDOMAIN_WILDCARD}}",
+    "subdomain": "{{SUBDOMAIN_WILDCARD}}",
+    "allowfrom": []
+  }
+}
+```
+
+`example.com` and `*.example.com` are separate registrations — each has its own UUID and its own credentials. They must both appear in `acmedns.json` if Traefik will be requesting both.
+
+**The key in `acmedns.json` must match the domain Traefik is requesting the certificate for.** If Traefik requests a SAN cert for `example.com` and `*.example.com`, both keys must be present.
+
+Mount this file read-only into the container. Do not commit it to version control — it contains credentials.
+
+---
+
+### docker-compose.yml — Traefik service
+
+The certificate resolver and all static configuration is defined via `command` args on the Traefik container:
+
+```yaml
+services:
+  traefik:
+    image: traefik:v3.6
+    restart: unless-stopped
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.acmedns.acme.email=your-email@example.com"
+      - "--certificatesresolvers.acmedns.acme.storage=/certs/acme.json"
+      - "--certificatesresolvers.acmedns.acme.dnschallenge.provider=acme-dns"
+      - "--certificatesresolvers.acmedns.acme.dnschallenge.delaybeforecheck=10"
+      - "--certificatesresolvers.acmedns.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53"
+    environment:
+      - ACME_DNS_API_BASE=https://acmedns.realworld.net.au
+      - ACME_DNS_STORAGE_PATH=/acme-dns-accounts/acmedns.json
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik-certs:/certs
+      - ./acmedns.json:/acme-dns-accounts/acmedns.json:ro
+    networks:
+      - proxy
+
+volumes:
+  traefik-certs:
+
+networks:
+  proxy:
+    external: true
+```
+
+| Command flag | Purpose |
+|---|---|
+| `providers.docker` | Discover services and labels from Docker |
+| `providers.docker.exposedbydefault=false` | Only route services with `traefik.enable=true` |
+| `entrypoints.web` / `websecure` | HTTP (80) and HTTPS (443) listeners |
+| `certificatesresolvers.acmedns.acme.email` | Contact email for Let's Encrypt account |
+| `certificatesresolvers.acmedns.acme.storage` | Path inside container for certificate storage |
+| `dnschallenge.provider=acme-dns` | Use the built-in acme-dns provider |
+| `dnschallenge.delaybeforecheck` | Seconds to wait after updating DNS before verifying. `10` is usually sufficient; increase if propagation is slow. |
+| `dnschallenge.resolvers` | **External DNS resolvers** for propagation checks. Required for internal/private domains where the local resolver cannot see the acme-dns records. |
+
+| Environment variable | Value |
+|---|---|
+| `ACME_DNS_API_BASE` | URL of the acme-dns `/update` endpoint base (no trailing slash) |
+| `ACME_DNS_STORAGE_PATH` | Path inside the Traefik container to the credential file |
+
+---
+
+### docker-compose.yml — Application service labels
+
+Each service that needs a TLS certificate is configured via Docker labels:
+
+```yaml
+services:
+  my-service:
+    image: my-image:latest
+    restart: unless-stopped
+    networks:
+      - proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.my-service.rule=Host(`example.com`) || Host(`www.example.com`)"
+      - "traefik.http.routers.my-service.entrypoints=websecure"
+      - "traefik.http.routers.my-service.tls=true"
+      - "traefik.http.routers.my-service.tls.certresolver=acmedns"
+      - "traefik.http.routers.my-service.tls.domains[0].main=example.com"
+      - "traefik.http.routers.my-service.tls.domains[0].sans=*.example.com"
+      - "traefik.http.services.my-service.loadbalancer.server.port=8080"
+
+networks:
+  proxy:
+    external: true
+```
+
+**Label notes:**
+
+| Label | Purpose |
+|---|---|
+| `traefik.enable=true` | Exposes this service to Traefik (required when `exposedbydefault=false`) |
+| `tls.certresolver=acmedns` | Tells Traefik to use the `acmedns` resolver defined in the command args |
+| `tls.domains[0].main` | Primary domain for the certificate |
+| `tls.domains[0].sans` | Additional SANs — use this for wildcard coverage |
+
+If you only need a single non-wildcard domain, omit the `tls.domains` labels and let Traefik infer the domain from the `Host()` router rule.
+
+---
+
+## Alternative: traefik.yml static config
+
+If the user prefers a static config file over command args, the certificate resolver can be defined in `traefik.yml` instead. Mount it at `/traefik.yml:ro` and remove the equivalent `--certificatesresolvers.*` and `--entrypoints.*` command args.
+
+```yaml
+entryPoints:
+  web:
+    address: ":80"
+  websecure:
+    address: ":443"
+
+providers:
+  docker:
+    exposedByDefault: false
+
+certificatesResolvers:
+  acmedns:
+    acme:
+      email: your-email@example.com
+      storage: /certs/acme.json
+      dnsChallenge:
+        provider: acme-dns
+        delayBeforeCheck: 10
+        resolvers:
+          - "1.1.1.1:53"
+          - "8.8.8.8:53"
+```
+
+Add the volume mount to the Traefik service:
+
+```yaml
+    volumes:
+      - ./traefik/traefik.yml:/traefik.yml:ro
+```
+
+---
+
+## Where to Put Each File
+
+| File | Location | Notes |
+|---|---|---|
+| `acmedns.json` | Mounted at the path set in `ACME_DNS_STORAGE_PATH` | Mount read-only (`:ro`). Keep outside version control. |
+| Labels | On each service in `docker-compose.yml` | One `certresolver` label per router |
+| `traefik.yml` (optional) | Mounted at `/traefik.yml` inside the container | Only if using static config file instead of command args |
+
+---
+
+## DNS Resolver Configuration
+
+**This is critical for internal/private domains.** When Traefik runs inside a network whose DNS resolver cannot see the acme-dns CNAME or TXT records (e.g. a corporate LAN, a Docker network with a local DNS server, or a split-horizon DNS setup), the DNS propagation check will fail even though the records are correct on the public internet.
+
+The `dnschallenge.resolvers` setting tells Traefik to bypass the local resolver and query external DNS servers directly:
+
+```
+--certificatesresolvers.acmedns.acme.dnschallenge.resolvers=1.1.1.1:53,8.8.8.8:53
+```
+
+This is included in the Docker Compose example above. **Always include this setting** — it is harmless for public domains and essential for internal ones.
+
+---
+
+## Renewal
+
+Renewal is fully automatic. Traefik monitors certificate expiry and renews via the acme-dns provider before expiry. No cron job or manual intervention is needed.
+
+The renewed certificate is written back to `acme.json` (the `storage` path). As long as that volume persists across container restarts, certificates survive redeployments without re-issuance.
+
+---
+
+## Verification
+
+Check Traefik logs for ACME and certificate activity:
+
+```bash
+docker compose logs traefik | grep -i "acme\|certificate\|dns"
+```
+
+Inspect the issued certificate directly:
+
+```bash
+echo | openssl s_client -connect example.com:443 -servername example.com 2>/dev/null | openssl x509 -noout -dates -subject
+```
+
+Expected output (Let's Encrypt certificate):
+
+```
+notBefore=Mar 24 00:00:00 2026 GMT
+notAfter=Jun 22 23:59:59 2026 GMT
+subject=CN=example.com
+```
+
+Check `acme.json` contains entries for your domains (file is on the Traefik host at the volume mount path):
+
+```bash
+cat /path/to/acme.json | python3 -m json.tool | grep -i "example.com"
+```
+
+---
+
+## Common Issues
+
+### Certificate not being issued
+
+- Confirm the `acmedns.json` key matches the domain exactly, including `*.` prefix for wildcards
+- Confirm `ACME_DNS_API_BASE` has no trailing slash
+- Confirm the CNAME record is in place and resolving (`dig CNAME _acme-challenge.{{DOMAIN}}`)
+- Check Traefik logs for the specific error — `acme-dns` errors surface there
+
+### DNS propagation check fails on internal network
+
+- Ensure `dnschallenge.resolvers` is set to external resolvers (`1.1.1.1:53,8.8.8.8:53`)
+- Verify from the Traefik host that external resolvers are reachable: `dig @1.1.1.1 _acme-challenge.{{DOMAIN}}`
+- If the network blocks outbound DNS (port 53), resolvers won't work — you may need to allowlist the resolver IPs in your firewall
+
+### Traefik container can't read acmedns.json
+
+- Check the mount path in `docker-compose.yml` matches `ACME_DNS_STORAGE_PATH`
+- Ensure the file exists on the host before starting the container
+- The `:ro` flag is fine — Traefik reads but does not write this file
+
+### Certificate valid but wrong domain
+
+- The `tls.domains[0].main` label overrides the domain inferred from the `Host()` rule
+- If both are set, ensure they are consistent
+- For SAN certs covering base and wildcard, both must appear in `acmedns.json`


### PR DESCRIPTION
Adds the acmedns Claude Code skill under `skills/acmedns/` plus a plugin manifest, so it is installable via the internal rwts marketplace (git-subdir). Additive only — does not touch the service.